### PR TITLE
Quiet-period debounce: sync a file only after it has stopped changing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased (yabo-san fork)
+
+- Quiet-period debounce (`sync.quiet_period`, default 20s; `sync.quiet_max_wait`, default 600s).
+  A file is only synced once it has stopped changing in both vaults for `quiet_period` seconds.
+  Fixes: editor autosaves (Obsidian saves every ~2s while typing) were each pushed to iCloud,
+  which forked the note into `note(1).md` / `note 2.md` ... `note 6.md` and then deleted the
+  original (observed 2026-09-01, 34 pushes of one note in 2.5 minutes).
+
 # Changelog
 
 ## [1.2.0] - 2026-07-05

--- a/config.yaml
+++ b/config.yaml
@@ -14,6 +14,11 @@ sync:
   stability_window: 3
   stabilize_wait: 8
   tiny_threshold: 8
+  # Seconds a file must stay unchanged (both vaults) before it is synced. Prevents
+  # editor autosaves from being pushed one by one, which makes iCloud fork
+  # conflict copies. 0 disables. quiet_max_wait caps the wait for files that never settle.
+  quiet_period: 20
+  quiet_max_wait: 600
 
 logging:
   console_level: "normal"      # quiet | normal | verbose

--- a/obsidian_sync/config.py
+++ b/obsidian_sync/config.py
@@ -23,6 +23,12 @@ class SyncConfig:
     poll_interval: int = 2
     stability_window: int = 3
     stabilize_wait: int = 8
+    # Quiet-period debounce: a file must go this many seconds without changing
+    # (in either vault) before it is synced. Editors autosave every ~2s while
+    # typing; pushing each save to iCloud makes iCloud fork conflict copies.
+    quiet_period: int = 20
+    # Upper bound on how long to keep waiting for quiet before syncing anyway.
+    quiet_max_wait: int = 600
     tiny_threshold: int = 8
     max_concurrent_io: int = 50
     # Logging
@@ -72,6 +78,8 @@ class SyncConfig:
             poll_interval=sync.get("poll_interval", 2),
             stability_window=sync.get("stability_window", 3),
             stabilize_wait=sync.get("stabilize_wait", 8),
+            quiet_period=sync.get("quiet_period", 20),
+            quiet_max_wait=sync.get("quiet_max_wait", 600),
             tiny_threshold=sync.get("tiny_threshold", 8),
             max_concurrent_io=sync.get("max_concurrent_io", 50),
             console_level=logging_cfg.get("console_level", "normal"),
@@ -135,6 +143,12 @@ class SyncConfig:
 
         if self.stability_window < 0:
             errors.append(("invalid_value", "critical", "stability_window cannot be negative"))
+
+        if self.quiet_period < 0:
+            errors.append(("invalid_value", "critical", "quiet_period cannot be negative"))
+
+        if self.quiet_max_wait < self.quiet_period:
+            errors.append(("invalid_value", "critical", "quiet_max_wait must be >= quiet_period"))
 
         return errors
 

--- a/obsidian_sync/sync_engine.py
+++ b/obsidian_sync/sync_engine.py
@@ -8,6 +8,7 @@ from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 
 from .sync_worker import FileSynchronizer
+from .disk_io import safe_mtime, size_or_zero
 
 
 @dataclass(frozen=True)
@@ -160,6 +161,52 @@ class SyncEngine:
             level="verbose",
         )
 
+    def _drain(self, queue: "asyncio.Queue[FileSyncEvent]") -> int:
+        """Discard every queued event for a file; we sync current on-disk state anyway."""
+        drained = 0
+        while not queue.empty():
+            try:
+                queue.get_nowait()
+                queue.task_done()
+                drained += 1
+            except asyncio.QueueEmpty:
+                break
+        return drained
+
+    def _fingerprint(self, rel_path: str) -> tuple:
+        local = os.path.join(self.config.local_vault, rel_path)
+        icloud = os.path.join(self.config.icloud_vault, rel_path)
+        return (safe_mtime(local), size_or_zero(local), safe_mtime(icloud), size_or_zero(icloud))
+
+    async def _wait_for_quiet(self, rel_path: str, queue: "asyncio.Queue[FileSyncEvent]") -> None:
+        """
+        Quiet-period debounce. Obsidian autosaves every ~2s while you type; syncing each
+        save pushes a half-written file to iCloud every few seconds, and iCloud responds by
+        forking conflict copies ("note(1).md", "note 2.md", ...) and eventually dropping
+        the original. So: only act once the file has stopped changing, in BOTH vaults, for
+        `quiet_period` seconds. Any change or new event during the window restarts it,
+        bounded by `quiet_max_wait` so a file that never settles still syncs eventually.
+        """
+        quiet = self.config.quiet_period
+        if quiet <= 0:
+            return
+        before = self._fingerprint(rel_path)
+        waited = 0
+        while True:
+            await asyncio.sleep(quiet)
+            waited += quiet
+            drained = self._drain(queue)
+            after = self._fingerprint(rel_path)
+            if after == before and drained == 0:
+                if waited > quiet:
+                    self.log.info("DEBOUNCE", f"{self.config.disp(rel_path)} quiet after {waited}s", level="normal")
+                return
+            if waited >= self.config.quiet_max_wait:
+                self.log.warn("DEBOUNCE", f"{self.config.disp(rel_path)} still changing after {waited}s; syncing anyway", level="important")
+                return
+            self.log.info("DEBOUNCE", f"{self.config.disp(rel_path)} still changing; waiting another {quiet}s", level="verbose")
+            before = after
+
     async def file_worker(self, rel_path: str):
         queue = self.file_queues[rel_path]
         while True:
@@ -167,12 +214,10 @@ class SyncEngine:
             pending_count = queue.qsize()
             
             # Drain all pending events since we'll sync current state anyway
-            while not queue.empty():
-                try:
-                    queue.get_nowait()
-                    queue.task_done()
-                except asyncio.QueueEmpty:
-                    break
+            pending_count = self._drain(queue)
+            
+            # Wait until the file stops changing before touching either vault.
+            await self._wait_for_quiet(rel_path, queue)
             
             self.active_tasks.add(rel_path)
             try:


### PR DESCRIPTION
## Quiet-period debounce: only sync a file once it has stopped changing

### Problem
Editors autosave while you type: Obsidian writes the file roughly every 2 seconds. Each write is a filesystem event, and each event became a push to iCloud. iCloud's own conflict handling then treated the rapid succession of versions as competing edits and forked the note into `note(1).md`, `note 2.md` … `note 6.md`, eventually deleting the original.

Observed 2026-09-01 on Windows 11 + iCloud for Windows: **34 pushes of a single note in 2.5 minutes** (from the daemon's own log), ending in a forked/deleted note. The per-file queues and duplicate protection already in 1.1/1.2 reduce the window but don't remove the cause, because the model is still "sync every event".

### Change
Sync a file only after it has been **stable in both vaults for `quiet_period` seconds** (default 20 s), with `quiet_max_wait` (default 600 s) as an upper bound so a file that never settles still gets synced. Same settle-time approach used by Syncthing (`fsWatcherDelayS`) and rsync-based syncers.

- `config.yaml`: new `sync.quiet_period` and `sync.quiet_max_wait` (documented)
- `obsidian_sync/config.py`: parse + defaults
- `obsidian_sync/sync_engine.py`: debounce before the push/pull decision; logs a `DEBOUNCE` line so the wait is visible
- `CHANGELOG.md`: entry

Config-gated: set `quiet_period: 0` to get the previous behavior.

### Result
Running continuously since 2026-09-01 on a ~1,000-note vault synced with a Mac: zero conflict copies, autosave storms collapse to one push per edit session. Logs show `DEBOUNCE` followed by a single `PUSH`.

### Notes
- No change to the three-way merge logic itself; this only changes *when* a file is considered ready.
- Happy to lower the default if you'd rather keep upstream behavior by default and make this opt-in.

### Interaction with #14 (one-shot mode)
No overlapping hunks: #14 changes `run()`, this touches `enqueue_file_event`/`file_worker` and config. One semantic note: with #14, a one-shot run awaits every per-file queue, so a file still being written would hold the exit for up to `quiet_max_wait`. If #14 lands first I'll add a follow-up so `run_continuously: false` bypasses the quiet period (or clamps it to a few seconds).
